### PR TITLE
Make install subkey async

### DIFF
--- a/devops/infrastructure/roles/admin/tasks/main.yml
+++ b/devops/infrastructure/roles/admin/tasks/main.yml
@@ -7,7 +7,7 @@
 
 - name: Copy bash_profile content to bashrc for non-interactive sessions
   blockinfile:
-    block: "{{ bash_data.stdout }}"
+    block: '{{ bash_data.stdout }}'
     path: ~/.bashrc
     insertbefore: BOF
 
@@ -16,3 +16,14 @@
 
 - name: Install subkey
   shell: cargo install --force subkey --git https://github.com/paritytech/substrate --version 2.0.1 --locked
+  async: 3600
+  poll: 0
+  register: install_result
+
+- name: Check whether install subkey task has finished
+  async_status:
+    jid: '{{ install_result.ansible_job_id }}'
+  register: job_result
+  until: job_result.finished
+  retries: 36
+  delay: 100


### PR DESCRIPTION
This PR makes the install subkey task of Ansible playbook an async task.

This will resolve the issue faced while installing subkey in Github actions. https://github.com/Joystream/joystream/pull/2518#issuecomment-878130826