### PR TITLE
Carthage substrate v3  update tests ignazio

### DIFF
--- a/runtime-modules/content/src/tests/fixtures.rs
+++ b/runtime-modules/content/src/tests/fixtures.rs
@@ -3011,6 +3011,17 @@ impl IssueNftFixture {
         }
     }
 
+    pub fn with_non_channel_owner(self, owner: MemberId) -> Self {
+        let new_params = NftIssuanceParameters::<Test> {
+            init_transactional_status: self.params.init_transactional_status.clone(),
+            nft_metadata: self.params.nft_metadata.clone(),
+            non_channel_owner: Some(owner),
+            royalty: self.params.royalty.clone(),
+
+        };
+        self.with_params(new_params)
+    }
+
     pub fn with_sender(self, sender: AccountId) -> Self {
         Self { sender, ..self }
     }
@@ -3019,12 +3030,36 @@ impl IssueNftFixture {
         Self { actor, ..self }
     }
 
+    pub fn with_init_status(
+        self,
+        init_transactional_status: InitTransactionalStatus<Test>,
+    ) -> Self {
+        let new_params = NftIssuanceParameters::<Test> {
+            init_transactional_status,
+            nft_metadata: self.params.nft_metadata.clone(),
+            non_channel_owner: self.params.non_channel_owner.clone(),
+            royalty: self.params.royalty.clone(),
+
+        };
+        self.with_params(new_params)
+    }
+
+    pub fn with_royalty(self, royalty_pct: Perbill) -> Self {
+        let new_params = NftIssuanceParameters::<Test> {
+            init_transactional_status: self.params.init_transactional_status.clone(),
+            nft_metadata: self.params.nft_metadata.clone(),
+            non_channel_owner: self.params.non_channel_owner.clone(),
+            royalty: Some(royalty_pct),
+
+        };
+        self.with_params(new_params)
+    }
+
     #[allow(dead_code)]
     pub fn with_video_id(self, video_id: VideoId) -> Self {
         Self { video_id, ..self }
     }
 
-    #[allow(dead_code)]
     pub fn with_params(self, params: NftIssuanceParameters<Test>) -> Self {
         Self { params, ..self }
     }

--- a/runtime-modules/content/src/tests/fixtures.rs
+++ b/runtime-modules/content/src/tests/fixtures.rs
@@ -3017,7 +3017,6 @@ impl IssueNftFixture {
             nft_metadata: self.params.nft_metadata.clone(),
             non_channel_owner: Some(owner),
             royalty: self.params.royalty.clone(),
-
         };
         self.with_params(new_params)
     }
@@ -3039,7 +3038,6 @@ impl IssueNftFixture {
             nft_metadata: self.params.nft_metadata.clone(),
             non_channel_owner: self.params.non_channel_owner.clone(),
             royalty: self.params.royalty.clone(),
-
         };
         self.with_params(new_params)
     }
@@ -3050,7 +3048,6 @@ impl IssueNftFixture {
             nft_metadata: self.params.nft_metadata.clone(),
             non_channel_owner: self.params.non_channel_owner.clone(),
             royalty: Some(royalty_pct),
-
         };
         self.with_params(new_params)
     }

--- a/runtime-modules/content/src/tests/mock.rs
+++ b/runtime-modules/content/src/tests/mock.rs
@@ -589,6 +589,13 @@ pub fn run_to_block(n: u64) {
     }
 }
 
+#[macro_export]
+macro_rules! last_event_eq {
+    ($e:expr) => {
+        assert_eq!(System::events().last().unwrap().event, MetaEvent::Content($e))
+    };
+}
+
 pub fn assert_event(tested_event: Event, number_of_events_after_call: usize) {
     // Ensure  runtime events length is equal to expected number of events after call
     assert_eq!(System::events().len(), number_of_events_after_call);

--- a/runtime-modules/content/src/tests/mock.rs
+++ b/runtime-modules/content/src/tests/mock.rs
@@ -600,14 +600,6 @@ macro_rules! last_event_eq {
     };
 }
 
-pub fn assert_event(tested_event: Event, number_of_events_after_call: usize) {
-    // Ensure  runtime events length is equal to expected number of events after call
-    assert_eq!(System::events().len(), number_of_events_after_call);
-
-    // Ensure  last emitted event is equal to expected one
-    assert_eq!(System::events().iter().last().unwrap().event, tested_event);
-}
-
 /// Get good params for open auction
 pub fn get_open_auction_params() -> OpenAuctionParams<Test> {
     OpenAuctionParams::<Test> {

--- a/runtime-modules/content/src/tests/mock.rs
+++ b/runtime-modules/content/src/tests/mock.rs
@@ -81,6 +81,7 @@ pub const PAYMENTS_NUMBER: u64 = 10;
 pub const DEFAULT_PAYOUT_CLAIMED: u64 = 100;
 pub const DEFAULT_PAYOUT_EARNED: u64 = 100;
 pub const DEFAULT_NFT_PRICE: u64 = 1000;
+pub const DEFAULT_ROYALTY: u32 = 1;
 
 // Creator tokens
 pub const DEFAULT_CREATOR_TOKEN_ISSUANCE: u64 = 1_000_000_000;
@@ -592,7 +593,10 @@ pub fn run_to_block(n: u64) {
 #[macro_export]
 macro_rules! last_event_eq {
     ($e:expr) => {
-        assert_eq!(System::events().last().unwrap().event, MetaEvent::Content($e))
+        assert_eq!(
+            System::events().last().unwrap().event,
+            MetaEvent::Content($e)
+        )
     };
 }
 

--- a/runtime-modules/content/src/tests/nft/accept_incoming_offer.rs
+++ b/runtime-modules/content/src/tests/nft/accept_incoming_offer.rs
@@ -1,9 +1,8 @@
 #![cfg(test)]
-use crate::tests::curators;
 use crate::tests::fixtures::{
     channel_reward_account_balance, create_default_member_owned_channel_with_video,
     create_initial_storage_buckets_helper, increase_account_balance_helper, ContentTest,
-    CreateChannelFixture, CreateVideoFixture, MetaEvent, UpdateChannelFixture,
+    CreateChannelFixture, CreateVideoFixture, MetaEvent,
 };
 use crate::tests::mock::*;
 use crate::*;

--- a/runtime-modules/content/src/tests/nft/accept_incoming_offer.rs
+++ b/runtime-modules/content/src/tests/nft/accept_incoming_offer.rs
@@ -1,9 +1,5 @@
 #![cfg(test)]
-use crate::tests::fixtures::{
-    channel_reward_account_balance, create_default_member_owned_channel_with_video,
-    create_initial_storage_buckets_helper, increase_account_balance_helper, ContentTest,
-    CreateChannelFixture, CreateVideoFixture, MetaEvent,
-};
+use crate::tests::fixtures::*;
 use crate::tests::mock::*;
 use crate::*;
 use frame_support::{assert_err, assert_ok};
@@ -181,79 +177,57 @@ fn accept_incoming_offer_no_incoming_offers() {
 }
 
 #[test]
-fn accept_incoming_offer_with_nft_owner_being_a_member_channel() {
-    let video_id = 1u64;
+fn accept_incoming_offer_ok_with_nft_member_owner_correctly_credited() {
     with_default_mock_builder(|| {
-        // Run to block one to see emitted events
-        run_to_block(1);
-        // channel with no reward account
-        CreateChannelFixture::default()
-            .with_sender(DEFAULT_MEMBER_ACCOUNT_ID)
+        ContentTest::default().with_video().setup();
+        IssueNftFixture::default()
+            .with_non_channel_owner(THIRD_MEMBER_ID)
+            .with_royalty(Perbill::from_percent(1))
+            .with_init_status(InitTransactionalStatus::<Test>::InitiatedOfferToMember(
+                SECOND_MEMBER_ID,
+                Some(DEFAULT_NFT_PRICE),
+            ))
             .call_and_assert(Ok(()));
-        CreateVideoFixture::default()
-            .with_sender(DEFAULT_MEMBER_ACCOUNT_ID)
-            .with_actor(ContentActor::Member(DEFAULT_MEMBER_ID))
-            .call_and_assert(Ok(()));
-
-        assert_ok!(Content::issue_nft(
-            Origin::signed(DEFAULT_MEMBER_ACCOUNT_ID),
-            ContentActor::Member(DEFAULT_MEMBER_ID),
-            video_id,
-            NftIssuanceParameters::<Test>::default(),
-        ));
-
         increase_account_balance_helper(SECOND_MEMBER_ACCOUNT_ID, DEFAULT_NFT_PRICE);
+        let royalty = Perbill::from_percent(DEFAULT_ROYALTY).mul_floor(DEFAULT_NFT_PRICE);
+        let platform_fee = Content::platform_fee_percentage().mul_floor(DEFAULT_NFT_PRICE);
 
-        // Offer nft
-        assert_ok!(Content::offer_nft(
-            Origin::signed(DEFAULT_MEMBER_ACCOUNT_ID),
-            video_id,
-            ContentActor::Member(DEFAULT_MEMBER_ID),
-            SECOND_MEMBER_ID,
-            Some(100u64), // price
-        ));
-
-        // Make an attempt to accept incoming nft offer if sender is owner and reward account is not set
         assert_ok!(Content::accept_incoming_offer(
             Origin::signed(SECOND_MEMBER_ACCOUNT_ID),
-            video_id
+            VideoId::one(),
         ));
 
-        // check owner balance increased by net profit
+        // check member owner balance increased by NFT PRICE - ROYALTY - FEE
         assert_eq!(
-            Balances::<Test>::usable_balance(DEFAULT_MEMBER_ACCOUNT_ID),
-            100u64 - (Content::platform_fee_percentage() * 100u64)
+            Balances::<Test>::usable_balance(THIRD_MEMBER_ACCOUNT_ID),
+            DEFAULT_NFT_PRICE - royalty - platform_fee,
         );
     })
 }
 
 #[test]
-fn accept_incoming_offer_reward_account_ok_with_curator_owner_channel_account_correctly_credited() {
+fn accept_incoming_offer_reward_account_ok_with_owner_channel_account_correctly_credited() {
     with_default_mock_builder(|| {
-        let video_id = NextVideoId::<Test>::get();
-        let channel_id = NextChannelId::<Test>::get();
-        ContentTest::with_curator_channel().with_video_nft().setup();
-
+        ContentTest::default().with_video().setup();
+        IssueNftFixture::default()
+            .with_royalty(Perbill::from_percent(1))
+            .with_init_status(InitTransactionalStatus::<Test>::InitiatedOfferToMember(
+                SECOND_MEMBER_ID,
+                Some(DEFAULT_NFT_PRICE),
+            ))
+            .call_and_assert(Ok(()));
         increase_account_balance_helper(SECOND_MEMBER_ACCOUNT_ID, DEFAULT_NFT_PRICE);
-        // Offer nft
-        assert_ok!(Content::offer_nft(
-            Origin::signed(LEAD_ACCOUNT_ID),
-            video_id,
-            ContentActor::Lead,
-            SECOND_MEMBER_ID,
-            Some(DEFAULT_NFT_PRICE),
-        ));
-        increase_account_balance_helper(SECOND_MEMBER_ACCOUNT_ID, DEFAULT_NFT_PRICE);
+        let platform_fee = Content::platform_fee_percentage().mul_floor(DEFAULT_NFT_PRICE);
 
         assert_ok!(Content::accept_incoming_offer(
             Origin::signed(SECOND_MEMBER_ACCOUNT_ID),
-            video_id
+            VideoId::one(),
         ));
 
-        // Failure checked
+        // check creator owner balance increased by NFT PRICE + ROYALTY - ROYALTY - FEE
         assert_eq!(
-            channel_reward_account_balance(channel_id),
-            DEFAULT_NFT_PRICE - Content::platform_fee_percentage().mul_floor(DEFAULT_NFT_PRICE)
+            channel_reward_account_balance(ChannelId::one()),
+            DEFAULT_NFT_PRICE - platform_fee,
         );
     })
 }

--- a/runtime-modules/content/src/tests/nft/accept_incoming_offer.rs
+++ b/runtime-modules/content/src/tests/nft/accept_incoming_offer.rs
@@ -32,11 +32,6 @@ fn accept_incoming_offer() {
             None,
         ));
 
-        // Runtime tested state before call
-
-        // Events number before tested calls
-        let number_of_events_before_call = System::events().len();
-
         // Accept nft offer
         assert_ok!(Content::accept_incoming_offer(
             Origin::signed(SECOND_MEMBER_ACCOUNT_ID),
@@ -56,10 +51,7 @@ fn accept_incoming_offer() {
         ));
 
         // Last event checked
-        assert_event(
-            MetaEvent::Content(RawEvent::OfferAccepted(video_id)),
-            number_of_events_before_call + 1,
-        );
+        last_event_eq!(RawEvent::OfferAccepted(video_id));
     })
 }
 

--- a/runtime-modules/content/src/tests/nft/buy_nft.rs
+++ b/runtime-modules/content/src/tests/nft/buy_nft.rs
@@ -135,11 +135,7 @@ fn buy_nft() {
         ));
 
         // Last event checked
-        assert_event(
-            MetaEvent::Content(RawEvent::NftBought(video_id, SECOND_MEMBER_ID)),
-            // 4 events: KilledAccount (SECOND_MEMBER_ACCOUNT_ID), NewAccount (channel reward acc), Endowed (channel reward acc), NFTBought
-            number_of_events_before_call + 4,
-        );
+        last_event_eq!(RawEvent::NftBought(video_id, SECOND_MEMBER_ID));
     })
 }
 
@@ -397,38 +393,7 @@ fn buy_now_ok_with_nft_owner_member_correctly_credited() {
 }
 
 #[test]
-fn buy_now_ok_with_nft_owner_curator_channel_correctly_credited() {
-    with_default_mock_builder(|| {
-        let video_id = 1u64;
-        ContentTest::with_curator_channel().setup();
-
-        CreateVideoFixture::default()
-            .with_sender(LEAD_ACCOUNT_ID)
-            .with_actor(ContentActor::Lead)
-            .with_nft_in_sale(DEFAULT_NFT_PRICE)
-            .call();
-
-        increase_account_balance_helper(SECOND_MEMBER_ACCOUNT_ID, DEFAULT_NFT_PRICE);
-        let platform_fee = Content::platform_fee_percentage().mul_floor(DEFAULT_NFT_PRICE);
-
-        increase_account_balance_helper(SECOND_MEMBER_ACCOUNT_ID, 100u64);
-        assert_ok!(Content::buy_nft(
-            Origin::signed(SECOND_MEMBER_ACCOUNT_ID),
-            video_id,
-            SECOND_MEMBER_ID,
-            100u64,
-        ));
-
-        assert_eq!(
-            channel_reward_account_balance(1u64),
-            // Default price - platform fee (since channel owner it retains royalty)
-            DEFAULT_NFT_PRICE - platform_fee,
-        )
-    })
-}
-
-#[test]
-fn buy_now_ok_with_nft_owner_member_channel_correctly_credited() {
+fn buy_now_ok_with_nft_owner_channel_correctly_credited() {
     with_default_mock_builder(|| {
         let video_id = 1u64;
         ContentTest::with_member_channel().setup();

--- a/runtime-modules/content/src/tests/nft/buy_nft.rs
+++ b/runtime-modules/content/src/tests/nft/buy_nft.rs
@@ -4,8 +4,6 @@ use crate::tests::mock::*;
 use crate::*;
 use frame_support::{assert_err, assert_ok};
 
-pub const DEFAULT_ROYALTY: u32 = 1;
-
 fn setup_nft_on_sale_scenario() {
     let video_id = NextVideoId::<Test>::get();
 
@@ -96,10 +94,6 @@ fn buy_nft() {
             ContentActor::Member(DEFAULT_MEMBER_ID),
             DEFAULT_NFT_PRICE,
         ));
-
-        // Runtime tested state before call
-        // Events number before tested calls
-        let number_of_events_before_call = System::events().len();
 
         // Buy nft
         assert_ok!(Content::buy_nft(

--- a/runtime-modules/content/src/tests/nft/cancel_buy_now.rs
+++ b/runtime-modules/content/src/tests/nft/cancel_buy_now.rs
@@ -34,11 +34,6 @@ fn cancel_buy_now() {
             DEFAULT_NFT_PRICE,
         ));
 
-        // Runtime tested state before call
-
-        // Events number before tested calls
-        let number_of_events_before_call = System::events().len();
-
         // Cancel buy now
         assert_ok!(Content::cancel_buy_now(
             Origin::signed(DEFAULT_MEMBER_ACCOUNT_ID),
@@ -58,13 +53,10 @@ fn cancel_buy_now() {
         ));
 
         // Last event checked
-        assert_event(
-            MetaEvent::Content(RawEvent::BuyNowCanceled(
-                video_id,
-                ContentActor::Member(DEFAULT_MEMBER_ID),
-            )),
-            number_of_events_before_call + 1,
-        );
+        last_event_eq!(RawEvent::BuyNowCanceled(
+            video_id,
+            ContentActor::Member(DEFAULT_MEMBER_ID),
+        ));
     })
 }
 

--- a/runtime-modules/content/src/tests/nft/cancel_nft_auction.rs
+++ b/runtime-modules/content/src/tests/nft/cancel_nft_auction.rs
@@ -33,11 +33,6 @@ fn cancel_nft_auction() {
             get_open_auction_params()
         ));
 
-        // Runtime tested state before call
-
-        // Events number before tested calls
-        let number_of_events_before_call = System::events().len();
-
         // Cancel nft auction
         assert_ok!(Content::cancel_open_auction(
             Origin::signed(DEFAULT_MEMBER_ACCOUNT_ID),
@@ -57,13 +52,10 @@ fn cancel_nft_auction() {
         ));
 
         // Last event checked
-        assert_event(
-            MetaEvent::Content(RawEvent::AuctionCanceled(
-                ContentActor::Member(DEFAULT_MEMBER_ID),
-                video_id,
-            )),
-            number_of_events_before_call + 1,
-        );
+        last_event_eq!(RawEvent::AuctionCanceled(
+            ContentActor::Member(DEFAULT_MEMBER_ID),
+            video_id,
+        ));
     })
 }
 

--- a/runtime-modules/content/src/tests/nft/cancel_offer.rs
+++ b/runtime-modules/content/src/tests/nft/cancel_offer.rs
@@ -33,11 +33,6 @@ fn cancel_offer() {
             None,
         ));
 
-        // Runtime tested state before call
-
-        // Events number before tested calls
-        let number_of_events_before_call = System::events().len();
-
         // Cancel offer
         assert_ok!(Content::cancel_offer(
             Origin::signed(DEFAULT_MEMBER_ACCOUNT_ID),
@@ -57,13 +52,10 @@ fn cancel_offer() {
         ));
 
         // Last event checked
-        assert_event(
-            MetaEvent::Content(RawEvent::OfferCanceled(
-                video_id,
-                ContentActor::Member(DEFAULT_MEMBER_ID),
-            )),
-            number_of_events_before_call + 1,
-        );
+        last_event_eq!(RawEvent::OfferCanceled(
+            video_id,
+            ContentActor::Member(DEFAULT_MEMBER_ID),
+        ));
     })
 }
 

--- a/runtime-modules/content/src/tests/nft/cancel_open_auction_bid.rs
+++ b/runtime-modules/content/src/tests/nft/cancel_open_auction_bid.rs
@@ -69,11 +69,6 @@ fn cancel_open_auction_bid() {
         make_content_module_account_existential_deposit();
         setup_open_auction_scenario_with_bid();
 
-        // Runtime tested state before call
-
-        // Events number before tested calls
-        let number_of_events_before_call = System::events().len();
-
         // Run to the block where bid lock duration expires
         let bid_lock_duration = Content::min_bid_lock_duration();
         run_to_block(bid_lock_duration + 1);
@@ -106,12 +101,7 @@ fn cancel_open_auction_bid() {
         ));
 
         // Last event checked
-        assert_event(
-            MetaEvent::Content(RawEvent::AuctionBidCanceled(SECOND_MEMBER_ID, video_id)),
-            // 4 events: NewAccount(SECOND_MEMBER_ACCOUNT_ID), Endowed(SECOND_MEMBER_ACCOUNT_ID),
-            // Transfer(module acc, SECOND_MEMBER_ACCOUNT_ID), AuctionBidCanceled
-            number_of_events_before_call + 4,
-        );
+        last_event_eq!(RawEvent::AuctionBidCanceled(SECOND_MEMBER_ID, video_id));
     })
 }
 

--- a/runtime-modules/content/src/tests/nft/claim_won_english_auction.rs
+++ b/runtime-modules/content/src/tests/nft/claim_won_english_auction.rs
@@ -77,11 +77,6 @@ fn settle_english_auction() {
             bid + existential_deposit
         );
 
-        // Runtime tested state before call
-
-        // Events number before tested calls
-        let number_of_events_before_call = System::events().len();
-
         // Run to the block where auction expires
         run_to_block(Content::max_auction_duration() + 1);
 
@@ -109,14 +104,11 @@ fn settle_english_auction() {
         ));
 
         // Last event checked
-        assert_event(
-            MetaEvent::Content(RawEvent::EnglishAuctionSettled(
-                SECOND_MEMBER_ID,
-                SECOND_MEMBER_ACCOUNT_ID,
-                video_id,
-            )),
-            number_of_events_before_call + 3,
-        );
+        last_event_eq!(RawEvent::EnglishAuctionSettled(
+            SECOND_MEMBER_ID,
+            SECOND_MEMBER_ACCOUNT_ID,
+            video_id,
+        ));
     })
 }
 

--- a/runtime-modules/content/src/tests/nft/destroy_nft.rs
+++ b/runtime-modules/content/src/tests/nft/destroy_nft.rs
@@ -24,11 +24,6 @@ fn destroy_nft() {
             NftIssuanceParameters::<Test>::default(),
         ));
 
-        // Runtime tested state before call
-
-        // Events number before tested calls
-        let number_of_events_before_call = System::events().len();
-
         // Sell nft
         assert_ok!(Content::destroy_nft(
             Origin::signed(DEFAULT_MEMBER_ACCOUNT_ID),
@@ -42,13 +37,10 @@ fn destroy_nft() {
         assert!(matches!(Content::video_by_id(video_id).nft_status, None));
 
         // Last event checked
-        assert_event(
-            MetaEvent::Content(RawEvent::NftDestroyed(
-                ContentActor::Member(DEFAULT_MEMBER_ID),
-                video_id,
-            )),
-            number_of_events_before_call + 1,
-        );
+        last_event_eq!(RawEvent::NftDestroyed(
+            ContentActor::Member(DEFAULT_MEMBER_ID),
+            video_id,
+        ));
     })
 }
 

--- a/runtime-modules/content/src/tests/nft/issue_nft.rs
+++ b/runtime-modules/content/src/tests/nft/issue_nft.rs
@@ -19,11 +19,6 @@ fn issue_nft() {
         // Video does not have an nft
         assert_eq!(None, Content::video_by_id(video_id).nft_status);
 
-        // Runtime tested state before call
-
-        // Events number before tested calls
-        let number_of_events_before_call = System::events().len();
-
         // Issue nft
         assert_ok!(Content::issue_nft(
             Origin::signed(DEFAULT_MEMBER_ACCOUNT_ID),
@@ -44,14 +39,11 @@ fn issue_nft() {
 
         // Last event checked
         let nft_issue_params = NftIssuanceParameters::<Test>::default();
-        assert_event(
-            MetaEvent::Content(RawEvent::NftIssued(
-                ContentActor::Member(DEFAULT_MEMBER_ID),
-                video_id,
-                nft_issue_params,
-            )),
-            number_of_events_before_call + 1,
-        );
+        last_event_eq!(RawEvent::NftIssued(
+            ContentActor::Member(DEFAULT_MEMBER_ID),
+            video_id,
+            nft_issue_params,
+        ));
     })
 }
 

--- a/runtime-modules/content/src/tests/nft/offer_nft.rs
+++ b/runtime-modules/content/src/tests/nft/offer_nft.rs
@@ -24,11 +24,6 @@ fn offer_nft() {
             NftIssuanceParameters::<Test>::default(),
         ));
 
-        // Runtime tested state before call
-
-        // Events number before tested calls
-        let number_of_events_before_call = System::events().len();
-
         // Offer nft
         assert_ok!(Content::offer_nft(
             Origin::signed(DEFAULT_MEMBER_ACCOUNT_ID),
@@ -53,15 +48,12 @@ fn offer_nft() {
         ));
 
         // Last event checked
-        assert_event(
-            MetaEvent::Content(RawEvent::OfferStarted(
-                video_id,
-                ContentActor::Member(DEFAULT_MEMBER_ID),
-                SECOND_MEMBER_ID,
-                None,
-            )),
-            number_of_events_before_call + 1,
-        );
+        last_event_eq!(RawEvent::OfferStarted(
+            video_id,
+            ContentActor::Member(DEFAULT_MEMBER_ID),
+            SECOND_MEMBER_ID,
+            None,
+        ));
     })
 }
 

--- a/runtime-modules/content/src/tests/nft/pick_open_auction_winner.rs
+++ b/runtime-modules/content/src/tests/nft/pick_open_auction_winner.rs
@@ -61,11 +61,6 @@ fn pick_open_auction_winner() {
             bid,
         ));
 
-        // Runtime tested state before call
-
-        // Events number before tested calls
-        let number_of_events_before_call = System::events().len();
-
         // Pick open auction winner
         assert_ok!(Content::pick_open_auction_winner(
             Origin::signed(DEFAULT_MEMBER_ACCOUNT_ID),
@@ -87,15 +82,12 @@ fn pick_open_auction_winner() {
         ));
 
         // Last event checked
-        assert_event(
-            MetaEvent::Content(RawEvent::OpenAuctionBidAccepted(
-                ContentActor::Member(DEFAULT_MEMBER_ID),
-                video_id,
-                SECOND_MEMBER_ID,
-                bid,
-            )),
-            number_of_events_before_call + 3,
-        );
+        last_event_eq!(RawEvent::OpenAuctionBidAccepted(
+            ContentActor::Member(DEFAULT_MEMBER_ID),
+            video_id,
+            SECOND_MEMBER_ID,
+            bid,
+        ));
     })
 }
 

--- a/runtime-modules/content/src/tests/nft/pick_open_auction_winner.rs
+++ b/runtime-modules/content/src/tests/nft/pick_open_auction_winner.rs
@@ -10,17 +10,12 @@ const AUCTION_DURATION: u64 = 10;
 #[test]
 fn pick_open_auction_winner() {
     with_default_mock_builder(|| {
-        // Run to block one to see emitted events
-        run_to_block(1);
-
         let video_id = NextVideoId::<Test>::get();
 
         // TODO: Should not be required afer https://github.com/Joystream/joystream/issues/3508
         make_content_module_account_existential_deposit();
 
-        create_initial_storage_buckets_helper();
-        increase_account_balance_helper(DEFAULT_MEMBER_ACCOUNT_ID, INITIAL_BALANCE);
-        create_default_member_owned_channel_with_video();
+        ContentTest::default().with_video().setup();
 
         // Issue nft
         assert_ok!(Content::issue_nft(
@@ -531,111 +526,72 @@ fn pick_open_auction_winner_fails_with_invalid_bid_commit() {
 }
 
 #[test]
-fn pick_open_auction_winner_ok_with_nft_owner_member_channel_correctly_credited() {
+fn pick_open_auction_winner_ok_with_nft_member_owner_correctly_credited() {
     with_default_mock_builder(|| {
-        let video_id = Content::next_video_id();
-        ContentTest::with_member_channel().with_video_nft().setup();
+        increase_account_balance_helper(SECOND_MEMBER_ACCOUNT_ID, DEFAULT_NFT_PRICE);
+        let royalty = Perbill::from_percent(DEFAULT_ROYALTY).mul_floor(DEFAULT_NFT_PRICE);
+        let platform_fee = Content::platform_fee_percentage().mul_floor(DEFAULT_NFT_PRICE);
+        ContentTest::default().with_video().setup();
+        IssueNftFixture::default()
+            .with_non_channel_owner(THIRD_MEMBER_ID)
+            .with_royalty(Perbill::from_percent(1))
+            .call_and_assert(Ok(()));
+        StartOpenAuctionFixture::default()
+            .with_sender(THIRD_MEMBER_ACCOUNT_ID)
+            .with_actor(ContentActor::Member(THIRD_MEMBER_ID))
+            .call_and_assert(Ok(()));
+        MakeOpenAuctionBidFixture::default()
+            .with_bid(DEFAULT_NFT_PRICE)
+            .call_and_assert(Ok(()));
 
-        let bid_lock_duration = Content::min_bid_lock_duration();
+        assert_ok!(
+            Content::pick_open_auction_winner(
+                Origin::signed(THIRD_MEMBER_ACCOUNT_ID),
+                ContentActor::Member(THIRD_MEMBER_ID),
+                VideoId::one(),
+                SECOND_MEMBER_ID,
+                DEFAULT_NFT_PRICE
+            ));
 
-        let auction_params = OpenAuctionParams::<Test> {
-            starting_price: Content::min_starting_price(),
-            buy_now_price: None,
-            bid_lock_duration,
-            starts_at: None,
-            whitelist: BTreeSet::new(),
-        };
-
-        // Start nft auction
-        assert_ok!(Content::start_open_auction(
-            Origin::signed(DEFAULT_MEMBER_ACCOUNT_ID),
-            ContentActor::Member(DEFAULT_MEMBER_ID),
-            video_id,
-            auction_params.clone(),
-        ));
-
-        // deposit initial balance
-        let bid = Content::min_starting_price();
-        let platform_fee = Content::platform_fee_percentage().mul_floor(bid);
-
-        let _ = balances::Pallet::<Test>::deposit_creating(&SECOND_MEMBER_ACCOUNT_ID, bid);
-
-        // Make nft auction bid
-        assert_ok!(Content::make_open_auction_bid(
-            Origin::signed(SECOND_MEMBER_ACCOUNT_ID),
-            SECOND_MEMBER_ID,
-            video_id,
-            bid,
-        ));
-
-        // Pick open auction winner
-        assert_ok!(Content::pick_open_auction_winner(
-            Origin::signed(DEFAULT_MEMBER_ACCOUNT_ID),
-            ContentActor::Member(DEFAULT_MEMBER_ID),
-            video_id,
-            SECOND_MEMBER_ID,
-            bid,
-        ));
-
-        assert_eq!(channel_reward_account_balance(1u64), bid - platform_fee);
+        // net revenue for member owner : NFT PRICE - ROYALTY - FEE
+        assert_eq!(
+            Balances::<Test>::usable_balance(THIRD_MEMBER_ACCOUNT_ID),
+            DEFAULT_NFT_PRICE - royalty - platform_fee
+        );
     })
 }
 
 #[test]
-fn pick_open_auction_winner_ok_with_nft_owner_curator_channel_correctly_credited() {
+fn pick_open_auction_ok_with_channel_owner_correctly_credited() {
     with_default_mock_builder(|| {
-        let video_id = Content::next_video_id();
-        ContentTest::with_curator_channel().with_video_nft().setup();
+        increase_account_balance_helper(SECOND_MEMBER_ACCOUNT_ID, DEFAULT_NFT_PRICE);
+         let platform_fee = Content::platform_fee_percentage().mul_floor(DEFAULT_NFT_PRICE);
+        ContentTest::default().with_video().setup();
+        IssueNftFixture::default()
+            .with_royalty(Perbill::from_percent(1))
+            .call_and_assert(Ok(()));
+        StartOpenAuctionFixture::default().call_and_assert(Ok(()));
+        MakeOpenAuctionBidFixture::default()
+            .with_bid(DEFAULT_NFT_PRICE)
+            .call_and_assert(Ok(()));
 
-        let bid_lock_duration = Content::min_bid_lock_duration();
+        assert_ok!(
+            Content::pick_open_auction_winner(
+                Origin::signed(DEFAULT_MEMBER_ACCOUNT_ID),
+                ContentActor::Member(DEFAULT_MEMBER_ID),
+                VideoId::one(),
+                SECOND_MEMBER_ID,
+                DEFAULT_NFT_PRICE
+            ));
 
-        let auction_params = OpenAuctionParams::<Test> {
-            starting_price: Content::min_starting_price(),
-            buy_now_price: None,
-            bid_lock_duration,
-            starts_at: None,
-            whitelist: BTreeSet::new(),
-        };
-
-        // Start nft auction
-        assert_ok!(Content::start_open_auction(
-            Origin::signed(LEAD_ACCOUNT_ID),
-            ContentActor::Lead,
-            video_id,
-            auction_params.clone(),
-        ));
-
-        // deposit initial balance
-        let bid = Content::min_starting_price();
-        let platform_fee = Content::platform_fee_percentage().mul_floor(bid);
-
-        let _ = balances::Pallet::<Test>::deposit_creating(&SECOND_MEMBER_ACCOUNT_ID, bid);
-
-        // Make nft auction bid
-        assert_ok!(Content::make_open_auction_bid(
-            Origin::signed(SECOND_MEMBER_ACCOUNT_ID),
-            SECOND_MEMBER_ID,
-            video_id,
-            bid,
-        ));
-
-        // Pick open auction winner
-        assert_ok!(Content::pick_open_auction_winner(
-            Origin::signed(LEAD_ACCOUNT_ID),
-            ContentActor::Lead,
-            video_id,
-            SECOND_MEMBER_ID,
-            bid,
-        ));
-
-        assert_eq!(channel_reward_account_balance(1u64), bid - platform_fee);
+        // net revenue for creator owner : NFT PRICE + ROYALTY - ROYALTY - FEE
+        assert_eq!(channel_reward_account_balance(ChannelId::one()), DEFAULT_NFT_PRICE - platform_fee);
     })
 }
 
 #[test]
 fn pick_open_auction_fails_during_channel_transfer() {
     with_default_mock_builder(|| {
-        run_to_block(1);
         ContentTest::default().with_nft_open_auction_bid().setup();
         UpdateChannelTransferStatusFixture::default()
             .with_new_member_channel_owner(THIRD_MEMBER_ID)
@@ -650,74 +606,6 @@ fn pick_open_auction_fails_during_channel_transfer() {
                 Content::min_starting_price(),
             ),
             Error::<Test>::InvalidChannelTransferStatus,
-        );
-    })
-}
-
-#[test]
-fn auction_proceeds_ok_in_case_of_member_owned_channel_with_no_reward_account_is_auctioneer() {
-    with_default_mock_builder(|| {
-        let video_id = Content::next_video_id();
-        CreateChannelFixture::default()
-            .with_sender(DEFAULT_MEMBER_ACCOUNT_ID)
-            //.with_actor(ContentActor::Member(DEFAULT_MEMBER_ID))
-            .call_and_assert(Ok(()));
-        CreateVideoFixture::default()
-            .with_sender(DEFAULT_MEMBER_ACCOUNT_ID)
-            .with_actor(ContentActor::Member(DEFAULT_MEMBER_ID))
-            .call();
-
-        assert_ok!(Content::issue_nft(
-            Origin::signed(DEFAULT_MEMBER_ACCOUNT_ID),
-            ContentActor::Member(DEFAULT_MEMBER_ID),
-            video_id,
-            NftIssuanceParameters::<Test>::default(),
-        ));
-
-        let bid_lock_duration = Content::min_bid_lock_duration();
-
-        let auction_params = OpenAuctionParams::<Test> {
-            starting_price: Content::min_starting_price(),
-            buy_now_price: None,
-            bid_lock_duration,
-            starts_at: None,
-            whitelist: BTreeSet::new(),
-        };
-
-        // Start nft auction
-        assert_ok!(Content::start_open_auction(
-            Origin::signed(DEFAULT_MEMBER_ACCOUNT_ID),
-            ContentActor::Member(DEFAULT_MEMBER_ID),
-            video_id,
-            auction_params.clone(),
-        ));
-
-        // deposit initial balance
-        let bid = Content::min_starting_price();
-        let platform_fee = Content::platform_fee_percentage().mul_floor(bid);
-
-        let _ = balances::Pallet::<Test>::deposit_creating(&SECOND_MEMBER_ACCOUNT_ID, bid);
-
-        // Make nft auction bid
-        assert_ok!(Content::make_open_auction_bid(
-            Origin::signed(SECOND_MEMBER_ACCOUNT_ID),
-            SECOND_MEMBER_ID,
-            video_id,
-            bid,
-        ));
-
-        // Pick open auction winner
-        assert_ok!(Content::pick_open_auction_winner(
-            Origin::signed(DEFAULT_MEMBER_ACCOUNT_ID),
-            ContentActor::Member(DEFAULT_MEMBER_ID),
-            video_id,
-            SECOND_MEMBER_ID,
-            bid,
-        ));
-
-        assert_eq!(
-            Balances::<Test>::usable_balance(DEFAULT_MEMBER_ACCOUNT_ID),
-            bid - platform_fee
         );
     })
 }

--- a/runtime-modules/content/src/tests/nft/sell_nft.rs
+++ b/runtime-modules/content/src/tests/nft/sell_nft.rs
@@ -26,12 +26,6 @@ fn sell_nft() {
             video_id,
             NftIssuanceParameters::<Test>::default(),
         ));
-
-        // Runtime tested state before call
-
-        // Events number before tested calls
-        let number_of_events_before_call = System::events().len();
-
         // Sell nft
         assert_ok!(Content::sell_nft(
             Origin::signed(DEFAULT_MEMBER_ACCOUNT_ID),
@@ -54,14 +48,11 @@ fn sell_nft() {
         ));
 
         // Last event checked
-        assert_event(
-            MetaEvent::Content(RawEvent::NftSellOrderMade(
+        last_event_eq!(RawEvent::NftSellOrderMade(
                 video_id,
                 ContentActor::Member(DEFAULT_MEMBER_ID),
                 DEFAULT_NFT_PRICE,
-            )),
-            number_of_events_before_call + 1,
-        );
+            ));
     })
 }
 

--- a/runtime-modules/content/src/tests/nft/sling_nft_back.rs
+++ b/runtime-modules/content/src/tests/nft/sling_nft_back.rs
@@ -36,9 +36,6 @@ fn sling_nft_back() {
             })
         ));
 
-        // Events number before tested calls
-        let number_of_events_before_call = System::events().len();
-
         // Sling nft back to the original artist
         assert_ok!(Content::sling_nft_back(
             Origin::signed(SECOND_MEMBER_ACCOUNT_ID),
@@ -58,13 +55,10 @@ fn sling_nft_back() {
         ));
 
         // Last event checked
-        assert_event(
-            MetaEvent::Content(RawEvent::NftSlingedBackToTheOriginalArtist(
+        last_event_eq!(RawEvent::NftSlingedBackToTheOriginalArtist(
                 video_id,
                 ContentActor::Member(SECOND_MEMBER_ID),
-            )),
-            number_of_events_before_call + 1,
-        );
+            ));
     })
 }
 

--- a/runtime-modules/content/src/tests/nft/update_buy_now.rs
+++ b/runtime-modules/content/src/tests/nft/update_buy_now.rs
@@ -35,11 +35,6 @@ fn update_buy_now_price() {
             DEFAULT_NFT_PRICE,
         ));
 
-        // Runtime tested state before call
-
-        // Events number before tested calls
-        let number_of_events_before_call = System::events().len();
-
         // update buy now price
         assert_ok!(Content::update_buy_now_price(
             Origin::signed(DEFAULT_MEMBER_ACCOUNT_ID),
@@ -58,14 +53,11 @@ fn update_buy_now_price() {
         ));
 
         // Last event checked
-        assert_event(
-            MetaEvent::Content(RawEvent::BuyNowPriceUpdated(
+        last_event_eq!(RawEvent::BuyNowPriceUpdated(
                 video_id,
                 ContentActor::Member(DEFAULT_MEMBER_ID),
                 NEW_NFT_PRICE,
-            )),
-            number_of_events_before_call + 1,
-        );
+            ));
     })
 }
 

--- a/runtime-modules/project-token/Cargo.toml
+++ b/runtime-modules/project-token/Cargo.toml
@@ -30,7 +30,6 @@ default = ['std']
 std = [
 	'sp-std/std',
 	'sp-io/std',
-	'sp-storage/std',
 	'sp-runtime/std',
 	'frame-support/std',
 	'frame-system/std',

--- a/runtime-modules/project-token/src/errors.rs
+++ b/runtime-modules/project-token/src/errors.rs
@@ -1,6 +1,6 @@
 use crate::Module;
 use frame_support::decl_error;
-use sp_std::convert::{TryFrom, TryInto};
+use sp_std::convert::{TryInto};
 
 decl_error! {
     pub enum Error for Module<T: crate::Config> {

--- a/runtime-modules/staking-handler/Cargo.toml
+++ b/runtime-modules/staking-handler/Cargo.toml
@@ -30,5 +30,4 @@ std = [
     'sp-arithmetic/std',
     'pallet-balances/std',
     'common/std',
-    'scale-info/std',
 ]

--- a/runtime-modules/storage/Cargo.toml
+++ b/runtime-modules/storage/Cargo.toml
@@ -52,8 +52,6 @@ std = [
     'pallet-timestamp/std',
     'sp-runtime/std',
     'common/std',
-    'membership/std',
-	'staking-handler/std',
     'scale-info/std',
 ]
 

--- a/runtime-modules/storage/src/lib.rs
+++ b/runtime-modules/storage/src/lib.rs
@@ -1021,7 +1021,7 @@ impl<WorkerId, AccountId> StorageBucketRecord<WorkerId, AccountId> {
 }
 
 // Helper-struct for the data object uploading.
-#[derive(Default, Clone, Debug)]
+#[derive(Default)]
 struct DataObjectCandidates<T: Config> {
     // next data object ID to be saved in the storage.
     next_data_object_id: T::DataObjectId,


### PR DESCRIPTION
Updated (and refactored) all the tests for the content pallet
##### Changes
- most of the failures where to the `assert_event` function, I replaced it with a `last_event_eq` macro like in the project token pallet (since we want only to check the last event emitted)
- We are no longer using reward account, but a module account for each channel. I have taken that in account for the tests in
`pick_open_auction_winner`, `buy_nft`, `accept_incoming_offer`