### PR TITLE
fix council subtract with underflow tests

### DIFF
--- a/runtime-modules/council/src/mock.rs
+++ b/runtime-modules/council/src/mock.rs
@@ -1493,7 +1493,7 @@ where
             }
 
             InstanceMockUtils::<Runtime>::increase_block_number(
-                start_block_number.into() - current_block_number + 1,
+                start_block_number.into() + 1 - current_block_number,
             );
         }
 

--- a/runtime-modules/council/src/tests.rs
+++ b/runtime-modules/council/src/tests.rs
@@ -1773,9 +1773,8 @@ fn council_many_cycle_rewards() {
         let origin = OriginType::Root;
         Mocks::set_budget(origin.clone(), u64::MAX.into(), Ok(()));
         for i in 0..num_iterations {
-            let iters = i * council_settings.cycle_duration;
             let tmp_params = Mocks::run_full_council_cycle(
-                iters,
+                i * council_settings.cycle_duration,
                 &council_members,
                 0,
             );

--- a/runtime-modules/council/src/tests.rs
+++ b/runtime-modules/council/src/tests.rs
@@ -1773,8 +1773,9 @@ fn council_many_cycle_rewards() {
         let origin = OriginType::Root;
         Mocks::set_budget(origin.clone(), u64::MAX.into(), Ok(()));
         for i in 0..num_iterations {
+            let iters = i * council_settings.cycle_duration;
             let tmp_params = Mocks::run_full_council_cycle(
-                i * council_settings.cycle_duration,
+                iters,
                 &council_members,
                 0,
             );


### PR DESCRIPTION
fixes `council::tests` error triggering subtraction with underflow.

#### Changes
replace `a - b + 1` with `a + 1 - b`