### PR TITLE
fix underflow errors in project token tests

### DIFF
--- a/runtime-modules/project-token/src/lib.rs
+++ b/runtime-modules/project-token/src/lib.rs
@@ -1006,8 +1006,8 @@ impl<T: Config>
         new_duration: Option<T::BlockNumber>,
     ) -> DispatchResult {
         let token_data = Self::ensure_token_exists(token_id)?;
-        let sale_id = token_data.next_sale_id - 1;
         let sale = OfferingStateOf::<T>::ensure_upcoming_sale_of::<T>(&token_data)?;
+        let sale_id = token_data.next_sale_id - 1;
 
         // Validate sale duration
         if let Some(duration) = new_duration {

--- a/runtime-modules/project-token/src/tests/canonical.rs
+++ b/runtime-modules/project-token/src/tests/canonical.rs
@@ -954,7 +954,7 @@ fn issue_token_ok_with_token_info_added() {
                     rate,
                 },
                 sale: None,
-                next_sale_id: 0,
+                next_sale_id: 1,
                 next_revenue_split_id: 0,
                 revenue_split: RevenueSplitState::Inactive,
             }

--- a/runtime-modules/project-token/src/tests/canonical.rs
+++ b/runtime-modules/project-token/src/tests/canonical.rs
@@ -954,7 +954,7 @@ fn issue_token_ok_with_token_info_added() {
                     rate,
                 },
                 sale: None,
-                next_sale_id: 1,
+                next_sale_id: 0,
                 next_revenue_split_id: 0,
                 revenue_split: RevenueSplitState::Inactive,
             }

--- a/runtime-modules/project-token/src/tests/test_utils.rs
+++ b/runtime-modules/project-token/src/tests/test_utils.rs
@@ -85,7 +85,7 @@ impl TokenDataBuilder {
             total_supply: Balance::zero(),
             sale: None,
             // reflect TokenData init setup
-            next_sale_id: 1,
+            next_sale_id: 0,
             transfer_policy: TransferPolicy::Permissionless,
             patronage_info: PatronageData::<Balance, BlockNumber> {
                 rate: BlockRate(Perquintill::zero()),

--- a/runtime-modules/project-token/src/tests/test_utils.rs
+++ b/runtime-modules/project-token/src/tests/test_utils.rs
@@ -84,7 +84,8 @@ impl TokenDataBuilder {
             tokens_issued: Balance::zero(),
             total_supply: Balance::zero(),
             sale: None,
-            next_sale_id: 0,
+            // reflect TokenData init setup
+            next_sale_id: 1,
             transfer_policy: TransferPolicy::Permissionless,
             patronage_info: PatronageData::<Balance, BlockNumber> {
                 rate: BlockRate(Perquintill::zero()),

--- a/runtime-modules/project-token/src/types.rs
+++ b/runtime-modules/project-token/src/types.rs
@@ -1201,7 +1201,7 @@ where
             transfer_policy: params.transfer_policy.into(),
             patronage_info,
              // in order to avoid underflow when Token is started idle and `update_upcoming_sale` is called`
-            next_sale_id: 1,
+            next_sale_id: 0,
             accounts_number: 0,
             revenue_split: RevenueSplitState::Inactive,
             next_revenue_split_id: 0,

--- a/runtime-modules/project-token/src/types.rs
+++ b/runtime-modules/project-token/src/types.rs
@@ -1200,7 +1200,8 @@ where
             sale: None,
             transfer_policy: params.transfer_policy.into(),
             patronage_info,
-            next_sale_id: 0,
+             // in order to avoid underflow when Token is started idle and `update_upcoming_sale` is called`
+            next_sale_id: 1,
             accounts_number: 0,
             revenue_split: RevenueSplitState::Inactive,
             next_revenue_split_id: 0,

--- a/runtime-modules/storage/src/lib.rs
+++ b/runtime-modules/storage/src/lib.rs
@@ -1021,6 +1021,7 @@ impl<WorkerId, AccountId> StorageBucketRecord<WorkerId, AccountId> {
 }
 
 // Helper-struct for the data object uploading.
+#[allow(dead_code)]
 #[derive(Default)]
 struct DataObjectCandidates<T: Config> {
     // next data object ID to be saved in the storage.


### PR DESCRIPTION
This is needed for the case Token is initialized in Idle state and
`update_upcoming_sale` is then called leading to underflow if the
initial value was 0.
_This should be reviewed by Leszek just to be sure I got the implementation right_ :heavy_check_mark: 